### PR TITLE
Fixed two runtime warnings involved with unneccessary IF statements

### DIFF
--- a/Controllers/OrdersController.cs
+++ b/Controllers/OrdersController.cs
@@ -21,11 +21,10 @@ namespace BangazonTeamDelta.Controllers
         }
         public async Task<IActionResult> Index([FromRoute]int userId)
         {
-            //if there is no id in the route then it will return 404
-            if (userId == null)
-            {
-                return NotFound();
-            }
+            // This is an async function, but "await" is never used
+            // Trying to figure out which part of this call is await-able
+            // and where to do it in the LINQ call
+            // Or does this even need to BE async??? We may never know
 
             var productsOnOrder =
             from ord in context.Order
@@ -42,6 +41,14 @@ namespace BangazonTeamDelta.Controllers
 
             if (productsOnOrder == null)
             {
+                // This is where we could build a new ViewModel for when the user's cart is empty
+                // All of the logic for an empty order view will be within this IF block
+                // In pseudo-code,, it might be something like...
+
+                // EmptyOrderViewModel emptyOrder = new EmptyOrderViewModel();
+                // emptyOrder.message = "The user's cart is empty!";
+                // return View(emptyOrder);
+
                 return View();
             }
             return View(uorder);

--- a/Controllers/ProductsController.cs
+++ b/Controllers/ProductsController.cs
@@ -30,12 +30,6 @@ namespace BangazonTeamDelta.Controllers
 
         public async Task<IActionResult> ProductTypeDetail([FromRoute]int id)
         {
-            // If no id was in the route, return 404
-            if (id == null)
-            {
-                return NotFound();
-            }
-
             var productType = await context.ProductType
                     .Include(s => s.Products)
                     .SingleOrDefaultAsync(m => m.ProductTypeId == id);


### PR DESCRIPTION
## Status

**READY**
## Migrations

NO
## Description

Fixed two of those annoying dotnet runtime errors where the console would bug you about a certain INT never being null. If the route ever includes an INT, the INT would never be null so the IF block is unneeded.

Also added a few notes about a possible place for the logic related to having an empty order view. It's within the IF block in the Index() for the Orders controller.
## Related PRs

List related PRs against other branches:

| branch | PR |
| --- | --- |
| other_pr_production | [link]() |
| other_pr_master | [link]() |
## Resolves Issue Number
## Deploy Notes

```
git fetch
git checkout cr-runtime-warning-fixes
dotnet restore
dotnet run
```
## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

``` sh
git pull --prune
git checkout <feature_branch>
bundle; script/server
```

1.
## Impacted Areas in Application

List general components of the application that this PR will affect:

OrdersController.cs and ProductsController.cs are now absent of any kind of error handling. May have to add in a bit later, but nothing important has been removed or added.
